### PR TITLE
Use optional chaining for sidebar-wrapper query

### DIFF
--- a/javascripts/discourse/components/focus-fullscreen-chat.js
+++ b/javascripts/discourse/components/focus-fullscreen-chat.js
@@ -16,13 +16,12 @@ export default class FocusFullscreenChat extends Component {
   forceDrawerMode(route) {
     if (route.name.startsWith("chat.")) {
       // when entering full screen chat, we don't want to force the state
-      document.querySelector(".sidebar-wrapper").classList.add("focused-chat");
+      document.querySelector(".sidebar-wrapper")?.classList.add("focused-chat");
       return;
     } else {
       // when leaving full screen chat, we want to force the state
       document
-        .querySelector(".sidebar-wrapper")
-        .classList.remove("focused-chat");
+        .querySelector(".sidebar-wrapper")?.classList.remove("focused-chat");
       this.chatStateManager.prefersDrawer();
       return;
     }


### PR DESCRIPTION
On mobile, and when the sidebar is disabled via site settings, this theme component is causing the header chat button to be unresponsive. This may be due a new recent [change to core ](https://github.com/discourse/discourse/pull/35884/files) refactoring the sidebar.

This PR loosens the dependency the theme component has on the sidebar being in place, which is now isn't on mobile and when disabled.